### PR TITLE
ET-12: Add Arabic localization for category names and 'user already registered' error

### DIFF
--- a/Backend/src/main/java/com/project/project/DTOs/ExpenseDTO.java
+++ b/Backend/src/main/java/com/project/project/DTOs/ExpenseDTO.java
@@ -1,0 +1,24 @@
+package com.project.project.DTOs;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Component;
+
+import com.project.project.enums.Category;
+import com.project.project.models.Expense;
+import lombok.Getter;
+import lombok.Setter;
+
+@Component
+@Setter
+@Getter
+public class ExpenseDTO {
+    private Long id;
+    private BigDecimal amount;
+    private String currencyCode;
+    private String description;
+    private LocalDateTime dateTime;
+    private String category;
+    private int userId;
+}

--- a/Backend/src/main/java/com/project/project/adapters/ExpensesAndDTOAdapter.java
+++ b/Backend/src/main/java/com/project/project/adapters/ExpensesAndDTOAdapter.java
@@ -1,0 +1,27 @@
+package com.project.project.adapters;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.stereotype.Component;
+
+import com.project.project.DTOs.ExpenseDTO;
+import com.project.project.models.Expense;
+import com.project.project.services.LocalizationService;
+
+@Component
+public class ExpensesAndDTOAdapter {
+    @Autowired
+    private LocalizationService localizationService;
+
+    public ExpenseDTO toDTO(Expense expense) {
+        ExpenseDTO expenseDTO = new ExpenseDTO();
+        expenseDTO.setId(expense.getId());
+        expenseDTO.setAmount(expense.getAmount());
+        expenseDTO.setDescription(expense.getDescription());
+        expenseDTO.setDateTime(expense.getDateTime());
+        expenseDTO.setCurrencyCode(expense.getCurrencyCode());
+        expenseDTO.setUserId(expense.getUser().getId());
+        expenseDTO.setCategory(localizationService.getCategoryName(expense.getCategory(), LocaleContextHolder.getLocale()));
+        return expenseDTO;
+    }
+}

--- a/Backend/src/main/java/com/project/project/config/LocaleResolverConfig.java
+++ b/Backend/src/main/java/com/project/project/config/LocaleResolverConfig.java
@@ -1,0 +1,18 @@
+package com.project.project.config;
+
+import java.util.Locale;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.LocaleResolver;
+import org.springframework.web.servlet.i18n.AcceptHeaderLocaleResolver;
+
+@Configuration
+public class LocaleResolverConfig {
+    @Bean
+    public LocaleResolver localeResolver() {
+        AcceptHeaderLocaleResolver sessionLocaleResolver = new AcceptHeaderLocaleResolver();
+        sessionLocaleResolver.setDefaultLocale(Locale.US);
+        return sessionLocaleResolver;
+    }
+}

--- a/Backend/src/main/java/com/project/project/controllers/ExpensesController.java
+++ b/Backend/src/main/java/com/project/project/controllers/ExpensesController.java
@@ -1,11 +1,14 @@
 package com.project.project.controllers;
 
+import com.project.project.DTOs.ExpenseDTO;
+import com.project.project.adapters.ExpensesAndDTOAdapter;
 import com.project.project.enums.Category;
 import com.project.project.models.Expense;
 import com.project.project.models.User;
 import com.project.project.repositories.UserRepo;
 import com.project.project.services.ExpensesService;
 import com.project.project.services.JwtService;
+import com.project.project.services.LocalizationService;
 import jakarta.servlet.http.HttpServletRequest;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Locale;
 
 @RestController
 @RequestMapping("/api/expenses")
@@ -37,13 +41,15 @@ public class ExpensesController {
     @Autowired
     private UserRepo userRepository;
 
+    @Autowired
+    private ExpensesAndDTOAdapter expensesAdapter;
 
     @PostMapping
-    public ResponseEntity<Expense> createExpense(@RequestBody Expense expense, HttpServletRequest request) {
+    public ResponseEntity<ExpenseDTO> createExpense(@RequestBody Expense expense, HttpServletRequest request, Locale locale) {
         User currentUser = jwtService.getAuthenticatedUser(request);
         expense.setUser(currentUser);
         Expense created = expensesService.createExpense(expense);
-        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+        return ResponseEntity.status(HttpStatus.CREATED).body(expensesAdapter.toDTO(created));
     }
 
     @GetMapping

--- a/Backend/src/main/java/com/project/project/services/AuthService.java
+++ b/Backend/src/main/java/com/project/project/services/AuthService.java
@@ -5,6 +5,7 @@ import com.project.project.enums.Role;
 import com.project.project.models.User;
 import com.project.project.repositories.UserRepo;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -23,11 +24,15 @@ public class AuthService {
     @Autowired
     JwtService jwtService;
 
+    @Autowired
+    private LocalizationService localizationService;
+
     private BCryptPasswordEncoder bCryptPasswordEncoder = new BCryptPasswordEncoder(12);
 
     public User register(User user) {
         if (userRepo.existsByUsername(user.getUsername())) {
-            throw new IllegalArgumentException("User already exists");
+            throw new IllegalArgumentException(localizationService.getMessage("user.already.exists",
+                    LocaleContextHolder.getLocale()));
         }
         String hashedPassword = bCryptPasswordEncoder.encode(user.getPassword());
         user.setPassword(hashedPassword);

--- a/Backend/src/main/java/com/project/project/services/LocalizationService.java
+++ b/Backend/src/main/java/com/project/project/services/LocalizationService.java
@@ -1,0 +1,31 @@
+package com.project.project.services;
+
+import org.springframework.context.MessageSource;
+import org.springframework.stereotype.Service;
+
+import java.util.Locale;
+
+@Service
+public class LocalizationService {
+
+    private final MessageSource messageSource;
+
+    public LocalizationService(MessageSource messageSource) {
+        this.messageSource = messageSource;
+    }
+
+    /**
+     * Get a localized message for a given key.
+     */
+    public String getMessage(String key, Locale locale) {
+        return messageSource.getMessage(key, null, locale);
+    }
+
+    /**
+     * Get localized category name.
+     */
+    public String getCategoryName(Enum<?> category, Locale locale) {
+        String key = "category." + category.name();
+        return messageSource.getMessage(key, null, locale);
+    }
+}

--- a/Backend/src/main/resources/application.properties
+++ b/Backend/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 spring.application.name=project
+spring.messages.basename=lang/messages
+spring.messages.encoding=UTF-8

--- a/Backend/src/main/resources/lang/messages.properties
+++ b/Backend/src/main/resources/lang/messages.properties
@@ -1,0 +1,8 @@
+category.EDUCATION=education
+category.FOOD=food
+category.MISCELLANEOUS=miscellaneous
+category.OUTING=outing
+category.TRANSPORTATION=transportation
+category.UTILITIES=utilities
+
+user.already.exists=User already exists

--- a/Backend/src/main/resources/lang/messages_ar.properties
+++ b/Backend/src/main/resources/lang/messages_ar.properties
@@ -1,0 +1,8 @@
+category.EDUCATION=تعليم
+category.FOOD=طعام
+category.MISCELLANEOUS=متنوع
+category.OUTING=نزهة
+category.TRANSPORTATION=نقل
+category.UTILITIES=خدمات
+
+user.already.exists=هذا الاسم مستخدم بالفعل


### PR DESCRIPTION
**Localization Support:**
* Added `LocalizationService` to centralize retrieval of localized messages and category names, using Spring's `MessageSource`.
* Configured locale resolution via `LocaleResolverConfig`, defaulting to US English, and set up message resource properties for localization.

**Expense API Refactor:**
* Introduced `ExpenseDTO` and `ExpensesAndDTOAdapter` to transform `Expense` entities into DTOs with localized category names.
* Updated `ExpensesController` to return `ExpenseDTO` instead of the raw `Expense` model, ensuring responses include localized category names.

**Localized Messages:**
* Added English and Arabic resource files for categories and error messages, supporting multi-language responses.
* Modified `AuthService` to use localized error messages when a user already exists.